### PR TITLE
removed redundant insert and added a missing define on mac os x

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -26,6 +26,9 @@
 #endif
 
 typedef u_int SOCKET;
+#ifdef __APPLE__
+#define MSG_NOSIGNAL        0
+#endif
 #ifdef WIN32
 #define MSG_NOSIGNAL        0
 #define MSG_DONTWAIT        0

--- a/serialize.h
+++ b/serialize.h
@@ -932,18 +932,6 @@ public:
     iterator insert(iterator it, const char& x=char()) { return vch.insert(it, x); }
     void insert(iterator it, size_type n, const char& x) { vch.insert(it, n, x); }
 
-    void insert(iterator it, const_iterator first, const_iterator last)
-    {
-        if (it == vch.begin() + nReadPos && last - first <= nReadPos)
-        {
-            // special case for inserting at the front when there's room
-            nReadPos -= (last - first);
-            memcpy(&vch[nReadPos], &first[0], last - first);
-        }
-        else
-            vch.insert(it, first, last);
-    }
-
     void insert(iterator it, std::vector<char>::const_iterator first, std::vector<char>::const_iterator last)
     {
         if (it == vch.begin() + nReadPos && last - first <= nReadPos)


### PR DESCRIPTION
Removed a redundant insert method definition (this was changed in bitcoin a long time ago, by you). Also there is no MSG_NOSIGNAL on mac os x so I added a define for it.

Both of these caused compilation errors on Mavericks.
