### PR TITLE
add missing newline in stdout printf

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -334,7 +334,7 @@ extern "C" void* ThreadStats(void*) {
       requests += dnsThread[i]->dns_opt.nRequests;
       queries += dnsThread[i]->dbQueries;
     }
-    printf("%s %i/%i available (%i tried in %is, %i new, %i active), %i banned; %llu DNS requests, %llu db queries", c, stats.nGood, stats.nAvail, stats.nTracked, stats.nAge, stats.nNew, stats.nAvail - stats.nTracked - stats.nNew, stats.nBanned, (unsigned long long)requests, (unsigned long long)queries);
+    printf("%s %i/%i available (%i tried in %is, %i new, %i active), %i banned; %llu DNS requests, %llu db queries\n", c, stats.nGood, stats.nAvail, stats.nTracked, stats.nAge, stats.nNew, stats.nAvail - stats.nTracked - stats.nNew, stats.nBanned, (unsigned long long)requests, (unsigned long long)queries);
     Sleep(1000);
   } while(1);
 }


### PR DESCRIPTION
The stdout printf looked really strange on my systems:
![bildschirmfoto 2015-03-12 um 21 06 07](https://cloud.githubusercontent.com/assets/178464/6627070/b858531e-c8fb-11e4-9bd2-9d5617d8ebee.png)

After adding a newline:
![bildschirmfoto 2015-03-12 um 21 07 55](https://cloud.githubusercontent.com/assets/178464/6627084/de2be524-c8fb-11e4-9c40-4f342527b8d1.png)

Or did i miss some hidden output features?