### PR TITLE
Add Another Method of Running Without Root

### DIFF
--- a/README
+++ b/README
@@ -45,3 +45,8 @@ $ iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353
 
 If properly configured, this will allow you to run dnsseed in userspace, using
 the -p 5353 option.
+
+Alternatively, you can use the CAP_NET_BIND_SERVICE capability on Linux kernel
+versions greater than 2.2.
+
+$ setcap 'cap_net_bind_service=+ep' /path/to/dnsseed

--- a/README
+++ b/README
@@ -47,6 +47,9 @@ If properly configured, this will allow you to run dnsseed in userspace, using
 the -p 5353 option.
 
 Alternatively, you can use the CAP_NET_BIND_SERVICE capability on Linux kernel
-versions greater than 2.2.
+versions greater than 2.6.24.
 
 $ setcap 'cap_net_bind_service=+ep' /path/to/dnsseed
+
+`setcap` usually comes pre-installed on most modern distributions, but is 
+available in the `libcap2-bin` package on debian and libcap2 on RedHat.


### PR DESCRIPTION
This adds what I feel is a better option than the `iptables` configuration rules, as these are much easier to misconfigure or neglect in ongoing maintenance.  Instead, I add documentation about using a built-in Linux feature to explicitly allow the `dnsseed` binary to listen on lower port numbers.