### PR TITLE
Add ipv4/ipv6 proxy, avoid connecting to invalid IPs

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -44,8 +44,8 @@ public:
                               "-d <threads>    Number of DNS server threads (default 4)\n"
                               "-p <port>       UDP port to listen on (default 53)\n"
                               "-o <ip:port>    Tor proxy IP/Port\n"
-                              "-i <ip:port>    IPV4 proxy IP/Port\n"
-                              "-k <ip:port>    IPV6 proxy IP/Port\n"
+                              "-i <ip:port>    IPV4 SOCKS5 proxy IP/Port\n"
+                              "-k <ip:port>    IPV6 SOCKS5 proxy IP/Port\n"
                               "--testnet       Use testnet\n"
                               "--wipeban       Wipe list of banned nodes\n"
                               "--wipeignore    Wipe list of ignored nodes\n"
@@ -63,7 +63,7 @@ public:
         {"port", required_argument, 0, 'p'},
         {"onion", required_argument, 0, 'o'},
         {"proxyipv4", required_argument, 0, 'i'},
-        {"proxyipv6", required_argument, 0, 'ik'},
+        {"proxyipv6", required_argument, 0, 'k'},
         {"testnet", no_argument, &fUseTestNet, 1},
         {"wipeban", no_argument, &fWipeBan, 1},
         {"wipeignore", no_argument, &fWipeBan, 1},

--- a/main.cpp
+++ b/main.cpp
@@ -27,6 +27,7 @@ public:
   const char *ns;
   const char *host;
   const char *tor;
+  const char *ipv4_proxy;
 
   CDnsSeedOpts() : nThreads(96), nDnsThreads(4), nPort(53), mbox(NULL), ns(NULL), host(NULL), tor(NULL), fUseTestNet(false), fWipeBan(false), fWipeIgnore(false) {}
 
@@ -42,6 +43,7 @@ public:
                               "-d <threads>    Number of DNS server threads (default 4)\n"
                               "-p <port>       UDP port to listen on (default 53)\n"
                               "-o <ip:port>    Tor proxy IP/Port\n"
+                              "-i <ip:port>    IPV4 proxy IP/Port\n"
                               "--testnet       Use testnet\n"
                               "--wipeban       Wipe list of banned nodes\n"
                               "--wipeignore    Wipe list of ignored nodes\n"
@@ -58,6 +60,7 @@ public:
         {"dnsthreads", required_argument, 0, 'd'},
         {"port", required_argument, 0, 'p'},
         {"onion", required_argument, 0, 'o'},
+        {"proxy", required_argument, 0, 'i'},
         {"testnet", no_argument, &fUseTestNet, 1},
         {"wipeban", no_argument, &fWipeBan, 1},
         {"wipeignore", no_argument, &fWipeBan, 1},
@@ -65,7 +68,7 @@ public:
         {0, 0, 0, 0}
       };
       int option_index = 0;
-      int c = getopt_long(argc, argv, "h:n:m:t:p:d:o:", long_options, &option_index);
+      int c = getopt_long(argc, argv, "h:n:m:t:p:d:o:i:", long_options, &option_index);
       if (c == -1) break;
       switch (c) {
         case 'h': {
@@ -103,6 +106,11 @@ public:
         
         case 'o': {
           tor = optarg;
+          break;
+        }
+        
+        case 'i': {
+          ipv4_proxy = optarg;
           break;
         }
 
@@ -369,6 +377,13 @@ int main(int argc, char **argv) {
     if (service.IsValid()) {
       printf("Using Tor proxy at %s\n", service.ToStringIPPort().c_str());
       SetProxy(NET_TOR, service);
+    }
+  }
+  if (opts.ipv4_proxy) {
+    CService service(opts.ipv4_proxy, 9050);
+    if (service.IsValid()) {
+      printf("Using IPv4 proxy at %s\n", service.ToStringIPPort().c_str());
+      SetProxy(NET_IPV4, service);
     }
   }
   bool fDNS = true;

--- a/main.cpp
+++ b/main.cpp
@@ -28,6 +28,7 @@ public:
   const char *host;
   const char *tor;
   const char *ipv4_proxy;
+  const char *ipv6_proxy;
 
   CDnsSeedOpts() : nThreads(96), nDnsThreads(4), nPort(53), mbox(NULL), ns(NULL), host(NULL), tor(NULL), fUseTestNet(false), fWipeBan(false), fWipeIgnore(false) {}
 
@@ -44,6 +45,7 @@ public:
                               "-p <port>       UDP port to listen on (default 53)\n"
                               "-o <ip:port>    Tor proxy IP/Port\n"
                               "-i <ip:port>    IPV4 proxy IP/Port\n"
+                              "-k <ip:port>    IPV6 proxy IP/Port\n"
                               "--testnet       Use testnet\n"
                               "--wipeban       Wipe list of banned nodes\n"
                               "--wipeignore    Wipe list of ignored nodes\n"
@@ -60,7 +62,8 @@ public:
         {"dnsthreads", required_argument, 0, 'd'},
         {"port", required_argument, 0, 'p'},
         {"onion", required_argument, 0, 'o'},
-        {"proxy", required_argument, 0, 'i'},
+        {"proxyipv4", required_argument, 0, 'i'},
+        {"proxyipv6", required_argument, 0, 'ik'},
         {"testnet", no_argument, &fUseTestNet, 1},
         {"wipeban", no_argument, &fWipeBan, 1},
         {"wipeignore", no_argument, &fWipeBan, 1},
@@ -68,7 +71,7 @@ public:
         {0, 0, 0, 0}
       };
       int option_index = 0;
-      int c = getopt_long(argc, argv, "h:n:m:t:p:d:o:i:", long_options, &option_index);
+      int c = getopt_long(argc, argv, "h:n:m:t:p:d:o:i:k:", long_options, &option_index);
       if (c == -1) break;
       switch (c) {
         case 'h': {
@@ -103,14 +106,19 @@ public:
           if (p > 0 && p < 65536) nPort = p;
           break;
         }
-        
+
         case 'o': {
           tor = optarg;
           break;
         }
-        
+
         case 'i': {
           ipv4_proxy = optarg;
+          break;
+        }
+
+        case 'k': {
+          ipv6_proxy = optarg;
           break;
         }
 
@@ -384,6 +392,13 @@ int main(int argc, char **argv) {
     if (service.IsValid()) {
       printf("Using IPv4 proxy at %s\n", service.ToStringIPPort().c_str());
       SetProxy(NET_IPV4, service);
+    }
+  }
+  if (opts.ipv6_proxy) {
+    CService service(opts.ipv6_proxy, 9050);
+    if (service.IsValid()) {
+      printf("Using IPv6 proxy at %s\n", service.ToStringIPPort().c_str());
+      SetProxy(NET_IPV6, service);
     }
   }
   bool fDNS = true;

--- a/netbase.cpp
+++ b/netbase.cpp
@@ -624,6 +624,11 @@ bool CNetAddr::IsRFC1918() const
         (GetByte(3) == 172 && (GetByte(2) >= 16 && GetByte(2) <= 31)));
 }
 
+bool CNetAddr::IsReserved() const
+{
+  return IsIPv4() && (GetByte(3) >= 240);
+}
+
 bool CNetAddr::IsRFC3927() const
 {
     return IsIPv4() && (GetByte(3) == 169 && GetByte(2) == 254);
@@ -740,7 +745,7 @@ bool CNetAddr::IsValid() const
 
 bool CNetAddr::IsRoutable() const
 {
-    return IsValid() && !(IsRFC1918() || IsRFC3927() || IsRFC4862() || (IsRFC4193() && !IsTor() && !IsI2P()) || IsRFC4843() || IsLocal());
+    return IsValid() && !(IsReserved() || IsRFC1918() || IsRFC3927() || IsRFC4862() || (IsRFC4193() && !IsTor() && !IsI2P()) || IsRFC4843() || IsLocal());
 }
 
 enum Network CNetAddr::GetNetwork() const

--- a/netbase.h
+++ b/netbase.h
@@ -47,6 +47,7 @@ class CNetAddr
         bool SetSpecial(const std::string &strName); // for Tor and I2P addresses
         bool IsIPv4() const;    // IPv4 mapped address (::FFFF:0:0/96, 0.0.0.0/0)
         bool IsIPv6() const;    // IPv6 address (not mapped IPv4, not Tor/I2P)
+        bool IsReserved() const; // Against Hetzners Abusal/Netscan Bot
         bool IsRFC1918() const; // IPv4 private networks (10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12)
         bool IsRFC3849() const; // IPv6 documentation address (2001:0DB8::/32)
         bool IsRFC3927() const; // IPv4 autoconfig (169.254.0.0/16)


### PR DESCRIPTION
This will add two new startup arguments (`-i` and `-k`) for setting an IPv4 or/and an IPv6 proxy.