### PR TITLE
Longer TTL

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -223,7 +223,7 @@ public:
     dns_opt.host = opts->host;
     dns_opt.ns = opts->ns;
     dns_opt.mbox = opts->mbox;
-    dns_opt.datattl = 60;
+    dns_opt.datattl = 3600;
     dns_opt.nsttl = 40000;
     dns_opt.cb = GetIPList;
     dns_opt.port = opts->nPort;


### PR DESCRIPTION
Due to the frequent complains about Bitcoin users being identified as participating in a "fast flux" attack due to the low TTL of the seeder's TTL, I think we should increase it significantly.

Perhaps some mechanism is needed where nodes add a (small) random prefix to the hostname to avoid everyone on the same ISP from getting the same results for an hour?