### PR TITLE
Wait for more than a single addr to come back

### DIFF
--- a/bitcoin.cpp
+++ b/bitcoin.cpp
@@ -26,9 +26,9 @@ class CNode {
 
   int GetTimeout() {
       if (you.IsTor())
-          return 60;
+          return 120;
       else
-          return 10;
+          return 30;
   }
 
   void BeginMessage(const char *pszCommand) {

--- a/bitcoin.cpp
+++ b/bitcoin.cpp
@@ -136,7 +136,9 @@ class CNode {
       // printf("%s: got %i addresses\n", ToString(you).c_str(), (int)vAddrNew.size());
       int64 now = time(NULL);
       vector<CAddress>::iterator it = vAddrNew.begin();
-      if (doneAfter == 0 || doneAfter > now + 1) doneAfter = now + 1;
+      if (vAddrNew.size() > 1) {
+        if (doneAfter == 0 || doneAfter > now + 1) doneAfter = now + 1;
+      }
       while (it != vAddrNew.end()) {
         CAddress &addr = *it;
 //        printf("%s: got address %s\n", ToString(you).c_str(), addr.ToString().c_str(), (int)(vAddr->size()));

--- a/main.cpp
+++ b/main.cpp
@@ -159,7 +159,7 @@ extern "C" void* ThreadCrawler(void* data) {
       res.nClientV = 0;
       res.nHeight = 0;
       res.strClientV = "";
-      bool getaddr = res.ourLastSuccess + 604800 < now;
+      bool getaddr = res.ourLastSuccess + 86400 < now;
       res.fGood = TestNode(res.service,res.nBanTime,res.nClientV,res.strClientV,res.nHeight,getaddr ? &addr : NULL);
     }
     db.ResultMany(ips);


### PR DESCRIPTION
Addresses #37.

Before, we would close the connection after receiving any addr message. Instead, wait until we receive more than one, as 0.12.x sends a addr message with its own data immediately after startup.

Note that this will not result in an infinite timeout, as we're already time limiting the life of connections. To make this change more effective, also increase the timeouts (which dated from a time when the codebase could not handle many concurrent connections).