### PR TITLE
Add MIT License file

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2009-2018 The Bitcoin Core developers
+Copyright (c) 2009-2018 Bitcoin Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
Fixes https://github.com/sipa/bitcoin-seeder/issues/20

Some files have a license text at the top, some don't, so it's not fully clear which license apply.
I picked Bitcoin Developers as copyright owners for now since the overlap seems fairly big.
Maybe you even want to move this repo to github.com/bitcoin one day, since it's an essential piece of the Bitcoin network and referenced in the Bitcoin Core documentation.
https://help.github.com/articles/transferring-a-repository-owned-by-your-personal-account/#transferring-to-an-organization might help :)