### PR TITLE
Recommend port 15353 when running in user space

### DIFF
--- a/README
+++ b/README
@@ -56,10 +56,10 @@ Typically, you'll need root privileges to listen to port 53 (name service).
 One solution is using an iptables rule (Linux only) to redirect it to
 a non-privileged port:
 
-$ iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353
+$ iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 15353
 
 If properly configured, this will allow you to run dnsseed in userspace, using
-the -p 5353 option.
+the -p 15353 option.
 
 Another solution is allowing a binary to bind to ports < 1024 with setcap (IPv6 access-safe)
 


### PR DESCRIPTION
Port 5353 is commonly used for mDNS (multicast DNS), so it's better to recommend a less-used port when running in user space. Some examples of commonly used applications that collide with this port include ipfs and avahi-daemon.