### PR TITLE
addrv2 BIP155 support

### DIFF
--- a/bitcoin.cpp
+++ b/bitcoin.cpp
@@ -113,6 +113,10 @@ class CNode {
       if (nVersion >= 209 && !vRecv.empty())
         vRecv >> nStartingHeight;
       
+      if (nVersion >= 70016) {
+        BeginMessage("sendaddrv2");
+        EndMessage();
+      }
       if (nVersion >= 209) {
         BeginMessage("verack");
         EndMessage();
@@ -130,10 +134,15 @@ class CNode {
       GotVersion();
       return false;
     }
-    
-    if (strCommand == "addr" && vAddr) {
+
+    bool addrv2 = strCommand == "addrv2";
+
+    if ((strCommand == "addr" || addrv2) && vAddr) {
+      if (addrv2)
+        vRecv.nVersion |= ADDRV2_FORMAT;
       vector<CAddress> vAddrNew;
       vRecv >> vAddrNew;
+      vRecv.nVersion &= ~ADDRV2_FORMAT;
       // printf("%s: got %i addresses\n", ToString(you).c_str(), (int)vAddrNew.size());
       int64 now = time(NULL);
       vector<CAddress>::iterator it = vAddrNew.begin();

--- a/db.h
+++ b/db.h
@@ -40,11 +40,11 @@ public:
     weight = weight * f + (1.0-f);
   }
   
-  IMPLEMENT_SERIALIZE (
+  IMPLEMENT_SERIALIZE {
     READWRITE(weight);
     READWRITE(count);
     READWRITE(reliability);
-  )
+  }
 
   friend class CAddrInfo;
 };
@@ -138,7 +138,7 @@ public:
   
   friend class CAddrDb;
   
-  IMPLEMENT_SERIALIZE (
+  IMPLEMENT_SERIALIZE {
     unsigned char version = 4;
     READWRITE(version);
     READWRITE(ip);
@@ -168,7 +168,7 @@ public:
       if (version >= 4)
           READWRITE(ourLastSuccess);
     }
-  )
+  }
 };
 
 class CAddrDbStats {
@@ -263,7 +263,7 @@ public:
   //   banned
   // acquires a shared lock (this does not suffice for read mode, but we assume that only happens at startup, single-threaded)
   // this way, dumping does not interfere with GetIPs_, which is called from the DNS thread
-  IMPLEMENT_SERIALIZE (({
+  IMPLEMENT_SERIALIZE {
     int nVersion = 0;
     READWRITE(nVersion);
     SHARED_CRITICAL_BLOCK(cs) {
@@ -303,7 +303,7 @@ public:
       }
       READWRITE(banned);
     }
-  });)
+  }
 
   void Add(const CAddress &addr, bool fForce = false) {
     CRITICAL_BLOCK(cs)

--- a/db.h
+++ b/db.h
@@ -101,7 +101,8 @@ public:
   }
   
   bool IsGood() const {
-    if (ip.GetPort() != GetDefaultPort()) return false;
+    if (ip.GetPort() != GetDefaultPort() && !ip.IsI2P())
+      return false;
     if (!(services & NODE_NETWORK)) return false;
     if (!ip.IsRoutable()) return false;
     if (clientVersion && clientVersion < REQUIRE_VERSION) return false;

--- a/db.h
+++ b/db.h
@@ -264,8 +264,8 @@ public:
   // acquires a shared lock (this does not suffice for read mode, but we assume that only happens at startup, single-threaded)
   // this way, dumping does not interfere with GetIPs_, which is called from the DNS thread
   IMPLEMENT_SERIALIZE {
-    int nVersion = 0;
-    READWRITE(nVersion);
+    int version = 0;
+    READWRITE(version);
     SHARED_CRITICAL_BLOCK(cs) {
       if (fWrite) {
         CAddrDb *db = const_cast<CAddrDb*>(this);

--- a/main.cpp
+++ b/main.cpp
@@ -418,7 +418,11 @@ extern "C" void* ThreadStats(void*) {
   return nullptr;
 }
 
-static const string mainnet_seeds[] = {"dnsseed.bluematt.me:8333", "bitseed.xf2.org:8333", "dnsseed.bitcoin.dashjr.org:8333", "seed.bitcoin.sipa.be:8333", ""};
+static const string mainnet_seeds[] = {"dnsseed.bluematt.me:8333", "bitseed.xf2.org:8333", "dnsseed.bitcoin.dashjr.org:8333", "seed.bitcoin.sipa.be:8333",
+"rp7k2go3s5lyj3fnj6zn62ktarlrsft2ohlsxkyd7v3e3idqyptvread.onion:8333",
+"qd6jlsevsexww3wefpqs7iglxb3f63y4e6ydulfzrvwflpicmdqa.b32.i2p:0",
+"[fcc7:be49:ccd1:dc91:3125:f0da:457d:8ce]:8333",
+""};
 static const string testnet_seeds[] = {"testnet-seed.alexykot.me:18333",
                                        "testnet-seed.bitcoin.petertodd.org:18333",
                                        "testnet-seed.bluematt.me:18333",

--- a/main.cpp
+++ b/main.cpp
@@ -363,7 +363,7 @@ extern "C" void* ThreadDumper(void*) {
       FILE *f = fopen("dnsseed.dat.new","w+");
       if (f) {
         {
-          CAutoFile cf(f);
+          CAutoFile cf(f, SER_DISK, PROTOCOL_VERSION | ADDRV2_FORMAT);
           cf << db;
         }
         rename("dnsseed.dat.new", "dnsseed.dat");
@@ -502,7 +502,7 @@ int main(int argc, char **argv) {
   FILE *f = fopen("dnsseed.dat","r");
   if (f) {
     printf("Loading dnsseed.dat...");
-    CAutoFile cf(f);
+    CAutoFile cf(f, SER_DISK, PROTOCOL_VERSION | ADDRV2_FORMAT);
     cf >> db;
     if (opts.fWipeBan)
         db.banned.clear();

--- a/main.cpp
+++ b/main.cpp
@@ -427,9 +427,6 @@ static const string testnet_seeds[] = {"testnet-seed.alexykot.me:18333",
 static const string *seeds = mainnet_seeds;
 
 extern "C" void* ThreadSeeder(void*) {
-  if (!fTestNet){
-    db.Add(CService("kjy2eqzk4zwi5zd3.onion", 8333), true);
-  }
   do {
     for (int i=0; seeds[i] != ""; i++) {
       vector<CService> ips;

--- a/main.cpp
+++ b/main.cpp
@@ -418,11 +418,11 @@ extern "C" void* ThreadStats(void*) {
   return nullptr;
 }
 
-static const string mainnet_seeds[] = {"dnsseed.bluematt.me", "bitseed.xf2.org", "dnsseed.bitcoin.dashjr.org", "seed.bitcoin.sipa.be", ""};
-static const string testnet_seeds[] = {"testnet-seed.alexykot.me",
-                                       "testnet-seed.bitcoin.petertodd.org",
-                                       "testnet-seed.bluematt.me",
-                                       "testnet-seed.bitcoin.schildbach.de",
+static const string mainnet_seeds[] = {"dnsseed.bluematt.me:8333", "bitseed.xf2.org:8333", "dnsseed.bitcoin.dashjr.org:8333", "seed.bitcoin.sipa.be:8333", ""};
+static const string testnet_seeds[] = {"testnet-seed.alexykot.me:18333",
+                                       "testnet-seed.bitcoin.petertodd.org:18333",
+                                       "testnet-seed.bluematt.me:18333",
+                                       "testnet-seed.bitcoin.schildbach.de:18333",
                                        ""};
 static const string *seeds = mainnet_seeds;
 
@@ -432,10 +432,10 @@ extern "C" void* ThreadSeeder(void*) {
   }
   do {
     for (int i=0; seeds[i] != ""; i++) {
-      vector<CNetAddr> ips;
-      LookupHost(seeds[i].c_str(), ips);
-      for (vector<CNetAddr>::iterator it = ips.begin(); it != ips.end(); it++) {
-        db.Add(CService(*it, GetDefaultPort()), true);
+      vector<CService> ips;
+      Lookup(seeds[i].c_str(), ips, GetDefaultPort());
+      for (vector<CService>::iterator it = ips.begin(); it != ips.end(); it++) {
+        db.Add(*it, true);
       }
     }
     Sleep(1800000);

--- a/netbase.cpp
+++ b/netbase.cpp
@@ -46,7 +46,7 @@ void SplitHostPort(std::string in, int &portOut, std::string &hostOut) {
         int n = strtol(in.c_str() + colon + 1, &endp, 10);
         if (endp && *endp == 0 && n >= 0) {
             in = in.substr(0, colon);
-            if (n > 0 && n < 0x10000)
+            if (n >= 0 && n < 0x10000)
                 portOut = n;
         }
     }

--- a/netbase.cpp
+++ b/netbase.cpp
@@ -835,16 +835,7 @@ enum Network CNetAddr::GetNetwork() const
     if (!IsRoutable())
         return NET_UNROUTABLE;
 
-    if (IsIPv4())
-        return NET_IPV4;
-
-    if (IsTor())
-        return NET_TOR;
-
-    if (IsI2P())
-        return NET_I2P;
-
-    return NET_IPV6;
+    return Network(networkId);
 }
 
 std::string CNetAddr::ToStringIP() const

--- a/netbase.h
+++ b/netbase.h
@@ -82,9 +82,9 @@ class CNetAddr
         friend bool operator<(const CNetAddr& a, const CNetAddr& b);
 
         IMPLEMENT_SERIALIZE
-            (
+            {
              READWRITE(FLATDATA(ip));
-            )
+            }
 };
 
 /** A combination of a network address (CNetAddr) and a (TCP) port */
@@ -120,14 +120,14 @@ class CService : public CNetAddr
         CService(const struct sockaddr_in6& addr);
 
         IMPLEMENT_SERIALIZE
-            (
+            {
              CService* pthis = const_cast<CService*>(this);
              READWRITE(FLATDATA(ip));
              unsigned short portN = htons(port);
              READWRITE(portN);
              if (fRead)
                  pthis->port = ntohs(portN);
-            )
+            }
 };
 
 enum Network ParseNetwork(std::string net);

--- a/netbase.h
+++ b/netbase.h
@@ -43,7 +43,6 @@ class CNetAddr
         explicit CNetAddr(const char *pszIp, bool fAllowLookup = false);
         explicit CNetAddr(const std::string &strIp, bool fAllowLookup = false);
         void Init();
-        void SetIP(const CNetAddr& ip);
         bool SetSpecial(const std::string &strName); // for Tor and I2P addresses
         bool IsIPv4() const;    // IPv4 mapped address (::FFFF:0:0/96, 0.0.0.0/0)
         bool IsIPv6() const;    // IPv6 address (not mapped IPv4, not Tor/I2P)
@@ -68,10 +67,7 @@ class CNetAddr
         std::string ToString() const;
         std::string ToStringIP() const;
         unsigned int GetByte(int n) const;
-        uint64 GetHash() const;
         bool GetInAddr(struct in_addr* pipv4Addr) const;
-        std::vector<unsigned char> GetGroup() const;
-        int GetReachabilityFrom(const CNetAddr *paddrPartner = NULL) const;
         void print() const;
 
         CNetAddr(const struct in6_addr& pipv6Addr);
@@ -110,7 +106,6 @@ class CService : public CNetAddr
         friend bool operator==(const CService& a, const CService& b);
         friend bool operator!=(const CService& a, const CService& b);
         friend bool operator<(const CService& a, const CService& b);
-        std::vector<unsigned char> GetKey() const;
         std::string ToString() const;
         std::string ToStringPort() const;
         std::string ToStringIPPort() const;
@@ -135,14 +130,11 @@ void SplitHostPort(std::string in, int &portOut, std::string &hostOut);
 bool SetProxy(enum Network net, CService addrProxy, int nSocksVersion = 5);
 bool GetProxy(enum Network net, CService &addrProxy);
 bool IsProxy(const CNetAddr &addr);
-bool SetNameProxy(CService addrProxy, int nSocksVersion = 5);
-bool GetNameProxy();
 bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions = 0, bool fAllowLookup = true);
 bool LookupHostNumeric(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions = 0);
 bool Lookup(const char *pszName, CService& addr, int portDefault = 0, bool fAllowLookup = true);
 bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault = 0, bool fAllowLookup = true, unsigned int nMaxSolutions = 0);
 bool LookupNumeric(const char *pszName, CService& addr, int portDefault = 0);
 bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout = nConnectTimeout);
-bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, int portDefault = 0, int nTimeout = nConnectTimeout);
 
 #endif

--- a/netbase.h
+++ b/netbase.h
@@ -12,6 +12,8 @@
 
 extern int nConnectTimeout;
 
+static constexpr int ADDRV2_FORMAT = 0x20000000;
+
 #ifdef WIN32
 // In MSVC, this is defined as a macro, undefine it to prevent a compile and link error
 #undef SetPort
@@ -22,8 +24,9 @@ enum Network
     NET_UNROUTABLE,
     NET_IPV4,
     NET_IPV6,
-    NET_TOR,
+    NET_TOR = 4,
     NET_I2P,
+    NET_CJDNS,
 
     NET_MAX,
 };
@@ -31,11 +34,12 @@ enum Network
 extern int nConnectTimeout;
 extern bool fNameLookup;
 
-/** IP address (IPv6, or IPv4 using mapped IPv6 range (::FFFF:0:0/96)) */
+/** Network address (IPv4, IPv6, TOR, I2P or CJDNS) */
 class CNetAddr
 {
     protected:
-        unsigned char ip[16]; // in network byte order
+        std::vector<unsigned char> vAddr; // raw address (in network byte order for IPv{4,6})
+        unsigned char networkId;                // Network to which this address belongs
 
     public:
         CNetAddr();
@@ -44,6 +48,8 @@ class CNetAddr
         explicit CNetAddr(const std::string &strIp, bool fAllowLookup = false);
         void Init();
         bool SetSpecial(const std::string &strName); // for Tor and I2P addresses
+        bool SetTor(const std::string &strName);
+        bool SetI2P(const std::string &strName);
         bool IsIPv4() const;    // IPv4 mapped address (::FFFF:0:0/96, 0.0.0.0/0)
         bool IsIPv6() const;    // IPv6 address (not mapped IPv4, not Tor/I2P)
         bool IsReserved() const; // Against Hetzners Abusal/Netscan Bot
@@ -59,6 +65,7 @@ class CNetAddr
         bool IsRFC6145() const; // IPv6 IPv4-translated address (::FFFF:0:0:0/96)
         bool IsTor() const;
         bool IsI2P() const;
+        bool IsCJDNS() const;
         bool IsLocal() const;
         bool IsRoutable() const;
         bool IsValid() const;

--- a/protocol.h
+++ b/protocol.h
@@ -40,13 +40,13 @@ class CMessageHeader
         bool IsValid() const;
 
         IMPLEMENT_SERIALIZE
-            (
+            {
              READWRITE(FLATDATA(pchMessageStart));
              READWRITE(FLATDATA(pchCommand));
              READWRITE(nMessageSize);
              if (nVersion >= 209)
              READWRITE(nChecksum);
-            )
+            }
 
     // TODO: make private (improves encapsulation)
     public:
@@ -75,7 +75,7 @@ class CAddress : public CService
         void Init();
 
         IMPLEMENT_SERIALIZE
-            (
+            {
              CAddress* pthis = const_cast<CAddress*>(this);
              CService* pip = (CService*)pthis;
              if (fRead)
@@ -86,7 +86,7 @@ class CAddress : public CService
              READWRITE(nTime);
              READWRITE(nServices);
              READWRITE(*pip);
-            )
+            }
 
         void print() const;
 
@@ -106,10 +106,10 @@ class CInv
         CInv(const std::string& strType, const uint256& hashIn);
 
         IMPLEMENT_SERIALIZE
-        (
+        {
             READWRITE(type);
             READWRITE(hash);
-        )
+        }
 
         friend bool operator<(const CInv& a, const CInv& b);
 

--- a/protocol.h
+++ b/protocol.h
@@ -82,8 +82,11 @@ class CAddress : public CService
                  pthis->Init();
              if (nType & SER_DISK)
              READWRITE(nVersion);
-             if ((nType & SER_DISK) || (nVersion >= 31402 && !(nType & SER_GETHASH)))
+             if ((nType & SER_DISK) || (nVersion >= 31402 && !(nType & SER_GETHASH)) || (nVersion & ADDRV2_FORMAT))
              READWRITE(nTime);
+             if (nVersion & ADDRV2_FORMAT)
+             READWRITE(COMPACTSIZE(nServices));
+             else
              READWRITE(nServices);
              READWRITE(*pip);
             }

--- a/serialize.h
+++ b/serialize.h
@@ -88,7 +88,7 @@ enum
     SER_BLOCKHEADERONLY = (1 << 17),
 };
 
-#define IMPLEMENT_SERIALIZE(statements)    \
+#define IMPLEMENT_SERIALIZE    \
     unsigned int GetSerializeSize(int nType=0, int nVersion=PROTOCOL_VERSION) const  \
     {                                           \
         CSerActionGetSerializeSize ser_action;  \
@@ -99,7 +99,7 @@ enum
         ser_streamplaceholder s;                \
         s.nType = nType;                        \
         s.nVersion = nVersion;                  \
-        {statements}                            \
+        REF(*this).SerializationOps(s, nType, nVersion, fGetSize, fWrite, fRead, nSerSize, ser_action);  \
         return nSerSize;                        \
     }                                           \
     template<typename Stream>                   \
@@ -110,7 +110,7 @@ enum
         const bool fWrite = true;               \
         const bool fRead = false;               \
         unsigned int nSerSize = 0;              \
-        {statements}                            \
+        REF(*this).SerializationOps(s, nType, nVersion, fGetSize, fWrite, fRead, nSerSize, ser_action);  \
     }                                           \
     template<typename Stream>                   \
     void Unserialize(Stream& s, int nType=0, int nVersion=PROTOCOL_VERSION)  \
@@ -120,8 +120,16 @@ enum
         const bool fWrite = false;              \
         const bool fRead = true;                \
         unsigned int nSerSize = 0;              \
-        {statements}                            \
-    }
+        SerializationOps(s, nType, nVersion, fGetSize, fWrite, fRead, nSerSize, ser_action);  \
+    }                                           \
+    template<typename Stream, typename Op>      \
+    void SerializationOps(Stream& s, int nType, int nVersion,  \
+                          const bool fGetSize,  \
+                          const bool fWrite,    \
+                          const bool fRead,     \
+                          unsigned int& nSerSize,  \
+                          Op ser_action)        \
+
 
 #define READWRITE(obj)      (nSerSize += ::SerReadWrite(s, (obj), nType, nVersion, ser_action))
 

--- a/serialize.h
+++ b/serialize.h
@@ -274,8 +274,6 @@ uint64 ReadCompactSize(Stream& is)
         READDATA(is, xSize);
         nSizeRet = xSize;
     }
-    if (nSizeRet > (uint64)MAX_SIZE)
-        throw std::ios_base::failure("ReadCompactSize() : size too large");
     return nSizeRet;
 }
 

--- a/serialize.h
+++ b/serialize.h
@@ -60,7 +60,7 @@ class CDataStream;
 class CAutoFile;
 static const unsigned int MAX_SIZE = 0x02000000;
 
-static const int PROTOCOL_VERSION = 60000;
+static const int PROTOCOL_VERSION = 70016;
 
 // Used to bypass the rule against non-const reference to temporary
 // where it makes sense with wrappers such as CFlatData or CTxDB

--- a/util.h
+++ b/util.h
@@ -103,4 +103,6 @@ std::string DecodeBase32(const std::string& str);
 std::string EncodeBase32(const unsigned char* pch, size_t len);
 std::string EncodeBase32(const std::string& str);
 
+uint256 SHA3_256(const void* pchData, size_t nSize);
+
 #endif


### PR DESCRIPTION
This is [BIP155](https://github.com/bitcoin/bips/blob/master/bip-0155.mediawiki) addrv2 support for TOR, I2P and CJDNS. 

Resolves #92.

Included in this pull request is the complete implementation of BIP155.

Serialization to disk always uses addrv2 format (in order to save TOR and I2P addresses in the database); Serialization on the network only uses the addrv2 format when serializing an addrv2 message; For all other cases, the old address format is used (particularly when serializing the version message and the old addr message).

Commits were kept small and descriptive to convey information from the original developer to the potential code reviewer.

Two optional commits were left out of this pull request for submission in a follow up. This is an enhancement to the proxy implementation which adds HTTP proxy support (useful with I2P) and command line flags for setting a proxy for I2P and CJDNS. As this is an enhacement, it was postponed to keep this pull request small. If you wish to check it out you may find it [here](https://github.com/siltribera/bitcoin-seeder/compare/addrv2...siltribera:bitcoin-seeder:addrv2-proxy).

The crawler does attempt to communicate with TOR, I2P and CJDNS nodes to collect peer addresses from them, possibly through a proxy if supplied in the command line.

This implementation was carefully tested prior to submission for each of TOR, I2P and CJDNS nodes.
