### PR TITLE
Add NODE_P2P_V2 to filters

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -166,11 +166,15 @@ public:
         filter_whitelist.insert(NODE_NETWORK | NODE_BLOOM); // x5
         filter_whitelist.insert(NODE_NETWORK | NODE_WITNESS); // x9
         filter_whitelist.insert(NODE_NETWORK | NODE_WITNESS | NODE_COMPACT_FILTERS); // x49
+        filter_whitelist.insert(NODE_NETWORK | NODE_WITNESS | NODE_P2P_V2); // x809
+        filter_whitelist.insert(NODE_NETWORK | NODE_WITNESS | NODE_P2P_V2 | NODE_COMPACT_FILTERS); //x849
         filter_whitelist.insert(NODE_NETWORK | NODE_WITNESS | NODE_BLOOM); // xd
         filter_whitelist.insert(NODE_NETWORK_LIMITED); // x400
         filter_whitelist.insert(NODE_NETWORK_LIMITED | NODE_BLOOM); // x404
         filter_whitelist.insert(NODE_NETWORK_LIMITED | NODE_WITNESS); // x408
         filter_whitelist.insert(NODE_NETWORK_LIMITED | NODE_WITNESS | NODE_COMPACT_FILTERS); // x448
+        filter_whitelist.insert(NODE_NETWORK_LIMITED | NODE_WITNESS | NODE_P2P_V2); // xc08
+        filter_whitelist.insert(NODE_NETWORK_LIMITED | NODE_WITNESS | NODE_P2P_V2 | NODE_COMPACT_FILTERS); // xc48
         filter_whitelist.insert(NODE_NETWORK_LIMITED | NODE_WITNESS | NODE_BLOOM); // x40c
     }
     if (host != NULL && ns == NULL) showHelp = true;

--- a/protocol.h
+++ b/protocol.h
@@ -64,6 +64,7 @@ enum
     NODE_WITNESS = (1 << 3),
     NODE_COMPACT_FILTERS = (1 << 6),
     NODE_NETWORK_LIMITED = (1 << 10),
+    NODE_P2P_V2 = (1 << 11),
 };
 
 class CAddress : public CService


### PR DESCRIPTION
Perhaps premature since https://github.com/bitcoin/bitcoin/pull/24545 hasn't been merged yet, but I figured it would be handy if at least one seed supports it. Mine does now, only on mainnet:

* `xc08.seed.bitcoin.sprovoost.nl` all SegWit enabled nodes including pruned ones
* `x809.seed.bitcoin.sprovoost.nl` all SegWit enabled full archive nodes (needed for IBD)
* for compact filters use `x849` for full archive nodes (or `xc48`, but Bitcoin Core only serves these filters on pruned nodes if they've been enabled since IBD, see https://github.com/bitcoin/bitcoin/pull/21726)

So far it's found one reachable node on IPv4.

Usage (IPv4 vs IPv6, results under `ANSWER SECTION`):

```
dig -t A xc08.seed.bitcoin.sprovoost.nl
dig -t AAAA xc08.seed.bitcoin.sprovoost.nl
```

Assuming modern node software won't need pre-segwit peers or bloom filters, these combinations have been omitted.

Someone should sanity check the hex values.