### PR TITLE
Add support for seeding other networks

### DIFF
--- a/db.cpp
+++ b/db.cpp
@@ -3,6 +3,8 @@
 
 using namespace std;
 
+int nMinimumHeight = 0;
+
 void CAddrInfo::Update(bool good) {
   uint32_t now = time(NULL);
   if (ourLastTry == 0)

--- a/db.h
+++ b/db.h
@@ -14,9 +14,10 @@
 
 #define REQUIRE_VERSION 70001
 
+extern int nMinimumHeight;
 static inline int GetRequireHeight(const bool testnet = fTestNet)
 {
-    return testnet ? 500000 : 350000;
+    return nMinimumHeight ? nMinimumHeight : (testnet ? 500000 : 350000);
 }
 
 std::string static inline ToString(const CService &ip) {

--- a/protocol.cpp
+++ b/protocol.cpp
@@ -22,6 +22,8 @@ static const char* ppszTypeName[] =
     "block",
 };
 
+unsigned short nDefaultP2Port = 0;
+
 unsigned char pchMessageStart[4] = { 0xf9, 0xbe, 0xb4, 0xd9 };
 
 CMessageHeader::CMessageHeader()

--- a/protocol.h
+++ b/protocol.h
@@ -16,9 +16,10 @@
 #include "uint256.h"
 
 extern bool fTestNet;
+extern unsigned short nDefaultP2Port;
 static inline unsigned short GetDefaultPort(const bool testnet = fTestNet)
 {
-    return testnet ? 18333 : 8333;
+    return nDefaultP2Port ? nDefaultP2Port : (testnet ? 18333 : 8333);
 }
 
 //


### PR DESCRIPTION
Adds four command-line options for specifying parameters necessary to run bitcoin-seeder as a DNS seed for bitcoin-like networks other than mainnet/testnet:

- “--seed <seed>” to override the built-in bitcoin seed nodes;
- “--p2port <port>” to specify the default port for the network;
- “--magic <hex>” to specify the protocol header/magic bytes; and
- “--minheight” to specify the minimum block height a node must report.

This is sufficient to enable bitcoin-seeder to be used for seeding signet, local regtest networks for testing, or networks more distantly related to bitcoin such as Blockstream's Liquid.